### PR TITLE
Create State-of-AI-for-Decarbonisation-2025.md

### DIFF
--- a/_pages/reports/State-of-AI-for-Decarbonisation-2025.md
+++ b/_pages/reports/State-of-AI-for-Decarbonisation-2025.md
@@ -1,0 +1,18 @@
+---
+title: "State of AI for Decarbonisation 2025"
+layout: single
+#classes: wide
+toc: false
+toc_sticky: true
+toc_icon: "cog"
+permalink: /reports/State_of_AI_for_Decarbonisation_2025
+author_profile: false
+---
+
+Read the report [here](https://www.turing.ac.uk/news/publications/state-ai-decarbonisation-2025)
+
+<iframe class="pdf" 
+                src=
+"https://www.turing.ac.uk/sites/default/files/2026-01/state_of_ai_for_decarbonisation_2025.pdf"
+            width="800" height="800">
+</iframe>


### PR DESCRIPTION
Added in the State of AI for Decarbonisation 2025 

I can't see how this will directly merge on the knowledge base. Please can we check that this is added to the top alongside the AI for Decarb Challenges and Ecosystem reports? It's currently nicely organised by ADViCE reports, then white papers, then DSG reports so just checking it goes where makes most sense!